### PR TITLE
read api-key from config and return it

### DIFF
--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -3054,52 +3054,52 @@ class Superset(BaseSupersetView):
                 stacktrace=utils.get_stacktrace(),
             )
 
-        @has_access
-        @expose("/geocoding")
-        def geocoding(self):
-            pass
+    @has_access
+    @expose("/geocoding")
+    def geocoding(self):
+        pass
 
-        @api
-        @has_access_api
-        @expose("/geocoding/columns", methods=["GET"])
-        def columns(self) -> Response:
-            return json_success("")
+    @api
+    @has_access_api
+    @expose("/geocoding/columns", methods=["GET"])
+    def columns(self) -> Response:
+        return json_success("")
 
-        @api
-        @has_access_api
-        @expose("/geocoding/geocode", methods=["GET"])
-        def geocode(self) -> Response:
-            return json_success("")
+    @api
+    @has_access_api
+    @expose("/geocoding/geocode", methods=["GET"])
+    def geocode(self) -> Response:
+        return json_success("")
 
-        def _get_mapbox_key(self):
-            pass
+    def _get_mapbox_key(self):
+        return conf["MAPBOX_API_KEY"]
 
-        def _check_table_config(self, tableName: str):
-            pass
+    def _check_table_config(self, tableName: str):
+        pass
 
-        def _geocode(self, data):
-            pass
+    def _geocode(self, data):
+        pass
 
-        def _add_lat_long_columns(self, data):
-            pass
+    def _add_lat_long_columns(self, data):
+        pass
 
-        @api
-        @has_access_api
-        @expose("/geocoding/is_in_progress", methods=["GET"])
-        def is_in_progress(self) -> Response:
-            return json_success("")
+    @api
+    @has_access_api
+    @expose("/geocoding/is_in_progress", methods=["GET"])
+    def is_in_progress(self) -> Response:
+        return json_success("")
 
-        @api
-        @has_access_api
-        @expose("/geocoding/progress", methods=["GET"])
-        def progress(self) -> Response:
-            return json_success("")
+    @api
+    @has_access_api
+    @expose("/geocoding/progress", methods=["GET"])
+    def progress(self) -> Response:
+        return json_success("")
 
-        @api
-        @has_access_api
-        @expose("/geocoding/interrupt", methods=["POST"])
-        def interrupt(self) -> Response:
-            return json_success("")
+    @api
+    @has_access_api
+    @expose("/geocoding/interrupt", methods=["POST"])
+    def interrupt(self) -> Response:
+        return json_success("")
 
 
 appbuilder.add_view_no_menu(Superset)

--- a/tests/geocoding_tests.py
+++ b/tests/geocoding_tests.py
@@ -1,0 +1,37 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Unit tests for geocoding"""
+
+from superset.views import core as views
+
+from .base_tests import SupersetTestCase
+
+
+class GeocodingTests(SupersetTestCase):
+    def __init__(self, *args, **kwargs):
+        super(GeocodingTests, self).__init__(*args, **kwargs)
+
+    def setUp(self):
+        self.login()
+
+    def tearDown(self):
+        self.logout()
+
+    def test_get_mapbox_api_key(self):
+        superset = views.Superset()
+        api_key = superset._get_mapbox_key()
+        assert isinstance(api_key, str)


### PR DESCRIPTION
… string was read

### CATEGORY

Choose one

- [ ] Bug Fix
- [x ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Read the Mapbox API Key from the config and return it, this method will be used by the geocoding API in order to be able to use the MapBox geocoding service.
Fix Indentation of newly added methods for geocoding
### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
